### PR TITLE
Refactor word inputs and add new SelectComponent approach

### DIFF
--- a/src/_pages/Dashboard/CreateWord.tsx
+++ b/src/_pages/Dashboard/CreateWord.tsx
@@ -77,8 +77,6 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
     },
     mode: "all",
   });
-  console.log('errors', formState.errors)
-  console.log("watch", watch())
   const { isOpen: isWordAttModalOpen, onOpenChange: onWordAttModalOpenChange, onOpen: onWordAttModalOpen, onClose: onWordAttributeClose } = useDisclosure()
   const { fields, append, prepend, remove } = useFieldArray({
     name: "meanings",
@@ -170,10 +168,10 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
           <WordAttributesInput setValue={setValue} control={control} onOpen={onWordAttModalOpen} />
         </div>
         {fields.length > 0 ? fields.map((field, index) => (
-          <div className="w-full mt-2">
+          <div key={field.id} className="w-full mt-2">
             <h2 className="text-center text-fs-1">Meanings</h2>
-            <Card key={field.id} className="mb-4 rounded-sm">
-              <CardBody className="flex flex-col gap-2">
+            <Card className="mb-4 rounded-sm">
+              <CardBody>
                 <WordMeaningInput index={index} control={control} />
                 <div className="grid sm:grid-cols-2 gap-2">
                   <MeaningPartOfSpeechInput index={index} control={control} partOfSpeeches={partOfSpeeches} />

--- a/src/_pages/Dashboard/CreateWord.tsx
+++ b/src/_pages/Dashboard/CreateWord.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Card,
   CardBody,
-  useDisclosure,
 } from "@nextui-org/react";
 import React from "react";
 import { useFieldArray, useForm } from "react-hook-form";
@@ -26,7 +25,6 @@ import { toast } from "sonner";
 import { api } from "@/src/trpc/react";
 import { PartOfSpeech } from "@/db/schema/part_of_speechs";
 import WordAttributesInput from "./CreateWordForm/Inputs/Word/WordAttributes";
-import AddWordAttributeModal from "@/src/components/customs/Modals/AddWordAttribute";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 
@@ -77,7 +75,6 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
     },
     mode: "all",
   });
-  const { isOpen: isWordAttModalOpen, onOpenChange: onWordAttModalOpenChange, onOpen: onWordAttModalOpen, onClose: onWordAttributeClose } = useDisclosure()
   const { fields, append, prepend, remove } = useFieldArray({
     name: "meanings",
     control,
@@ -153,8 +150,6 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
     wordMutation.mutate(word as WordFormSubmit)
     // reset();
   };
-  console.log('meanings', watch('meanings'))
-  console.log('errors', formState.errors)
   return (
     <section className="max-w-7xl w-full mx-auto max-sm:px-4 py-4">
       <h1 className="text-center text-fs-2">Create Word</h1>
@@ -166,7 +161,7 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
           <WordRootOriginInput control={control} watch={watch} setError={setError} clearErrors={clearErrors} getFieldState={getFieldState} />
           <WordPrefixInput control={control} />
           <WordSuffixInput control={control} />
-          <WordAttributesInput setValue={setValue} control={control} onOpen={onWordAttModalOpen} />
+          <WordAttributesInput setValue={setValue} control={control} />
         </div>
         {fields.length > 0 ? fields.map((field, index) => (
           <div key={field.id} className="w-full mt-2">
@@ -209,7 +204,6 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
           Submit
         </Button>
       </form>
-      <AddWordAttributeModal isOpen={isWordAttModalOpen} onClose={onWordAttributeClose} onOpenChange={onWordAttModalOpenChange} />
     </section>
   );
 }

--- a/src/_pages/Dashboard/CreateWord.tsx
+++ b/src/_pages/Dashboard/CreateWord.tsx
@@ -47,7 +47,7 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
     attribute: string;
   }[]
   authors: {
-    id: number;
+    id: string;
     name: string;
   }[]
   partOfSpeeches: {
@@ -104,7 +104,7 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
         partOfSpeechId: meaning.partOfSpeechId,
         example: meaning.example?.sentence && meaning.example?.sentence ? {
           sentence: meaning.example.sentence,
-          author: meaning.example.author,
+          author: meaning.example.author ? parseInt(meaning.example.author) : null,
         } : undefined,
         attributes: meaning.attributes?.map(attribute => parseInt(attribute))
       }
@@ -153,7 +153,8 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
     wordMutation.mutate(word as WordFormSubmit)
     // reset();
   };
-  // const meaningAttributesQuery = api.admin.getMeaningAttributes.useQuery()
+  console.log('meanings', watch('meanings'))
+  console.log('errors', formState.errors)
   return (
     <section className="max-w-7xl w-full mx-auto max-sm:px-4 py-4">
       <h1 className="text-center text-fs-2">Create Word</h1>
@@ -176,8 +177,8 @@ export default function CreateWord({ locale, meaningAttributes, authors, partOfS
                 <div className="grid sm:grid-cols-2 gap-2">
                   <MeaningPartOfSpeechInput index={index} control={control} partOfSpeeches={partOfSpeeches} />
                   <MeaningAttributesInput index={index} control={control} meaningAttributes={meaningAttributes} setFieldValue={setValue} />
-                  <MeaningExampleSentenceInput index={index} control={control} errors={formState.errors} clearErrors={clearErrors} getFieldState={getFieldState} setError={setError} watch={watch} />
-                  <MeaningExampleAuthorInput index={index} control={control} defaultExampleSentenceAuthors={authors} clearErrors={clearErrors} getFieldState={getFieldState} setError={setError} watch={watch} errors={formState.errors} />
+                  <MeaningExampleSentenceInput index={index} control={control} watch={watch} />
+                  <MeaningExampleAuthorInput index={index} control={control} defaultExampleSentenceAuthors={authors} clearErrors={clearErrors} watch={watch} setFieldValue={setValue} />
                 </div>
                 <div className="grid gap-2">
                   <MeaningImageInput index={index} control={control} formState={formState} clearErrors={clearErrors} field={field} setImagePreviewUrls={setImagePreviewUrls} imagePreviewUrls={imagePreviewUrls} />

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/AttributesInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/AttributesInput.tsx
@@ -47,12 +47,15 @@ export default function MeaningAttributesInput({
                 render={({ field, fieldState: { error } }) => (
                     <Select {...field}
                         as={'div'}
+                        tabIndex={0}
                         radius='sm'
                         label="Attributes"
                         classNames={{
-                            trigger: "pl-1 h-12 min-h-12",
+                            trigger: "pl-1",
                         }}
                         labelPlacement='outside'
+                        description="Attribute is optional"
+                        placeholder='Select a meaning attribute'
                         selectionMode='multiple'
                         onChange={handleSelectionChange}
                         isLoading={isLoading}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleAuthorInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleAuthorInput.tsx
@@ -1,4 +1,6 @@
+"use client"
 import AddAuthorModal from '@/src/components/customs/Modals/AddAuthor';
+import { api } from '@/src/trpc/react';
 import { WordForm } from '@/types'
 import { Button, Select, Selection, SelectItem, useDisclosure } from '@nextui-org/react'
 import { Plus } from 'lucide-react';
@@ -30,6 +32,9 @@ export default function MeaningxampleSentenceAuthorInput({
         setValue(() => new Set(selectedAuthor))
         setFieldValue(`meanings.${index}.example.author`, selectedAuthor)
     };
+    const { data } = api.admin.getExampleSentenceAuthors.useQuery(undefined, {
+        initialData: defaultExampleSentenceAuthors
+    });
     return (
         <Controller
             control={control} name={`meanings.${index}.example.author`}
@@ -75,7 +80,7 @@ export default function MeaningxampleSentenceAuthorInput({
                         )}
                     >
                         {
-                            defaultExampleSentenceAuthors.map((att) => (
+                            data.map((att) => (
                                 <SelectItem key={att.id}>
                                     {att.name}
                                 </SelectItem>

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleSentenceInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleSentenceInput.tsx
@@ -1,6 +1,6 @@
+"use client"
 import { WordForm } from '@/types'
 import { Input } from '@nextui-org/react'
-import clsx from 'clsx'
 import React from 'react'
 import { Control, Controller, UseFormWatch } from 'react-hook-form'
 
@@ -34,7 +34,7 @@ export default function MeaningExampleSentenceInput({
                         labelPlacement='outside'
                         isInvalid={!!errors?.meanings?.[index]?.example?.sentence}
                         errorMessage={errors.meanings?.[index]?.example?.sentence?.message}
-                        description="Example sentence is optional but required when example author is specified."
+                        description="Sentence is required when author is specified."
                     />
                 </>
             )}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleSentenceInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleSentenceInput.tsx
@@ -51,9 +51,9 @@ export default function MeaningExampleSentenceInput({
                 <>
                     <Input
                         {...field}
+                        radius='sm'
                         label="Example Sentence"
-                        color="primary"
-                        variant="underlined"
+                        labelPlacement='outside'
                         isInvalid={!!errors?.meanings?.[index]?.example?.sentence}
                         classNames={{
                             description: clsx({

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleSentenceInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ExampleSentenceInput.tsx
@@ -2,24 +2,15 @@ import { WordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import clsx from 'clsx'
 import React from 'react'
-import { Control, Controller, FieldErrors, UseFormClearErrors, UseFormGetFieldState, UseFormSetError, UseFormWatch } from 'react-hook-form'
+import { Control, Controller, UseFormWatch } from 'react-hook-form'
 
 export default function MeaningExampleSentenceInput({
     index,
     control,
-    errors,
-    getFieldState,
-    setError,
-    clearErrors,
     watch,
 }: {
     index: number,
     control: Control<WordForm>,
-    errors: FieldErrors<WordForm>
-    getFieldState: UseFormGetFieldState<WordForm>,
-
-    setError: UseFormSetError<WordForm>,
-    clearErrors: UseFormClearErrors<WordForm>,
     watch: UseFormWatch<WordForm>,
 }) {
     return (
@@ -27,27 +18,14 @@ export default function MeaningExampleSentenceInput({
             name={`meanings.${index}.example.sentence`}
             control={control}
             rules={{
-                validate: (value) => {
-                    const exampleSentence = `meanings.${index}.example.sentence` as const
-                    const quoteAuthor = `meanings.${index}.example.author` as const
-                    if (
-                        !value &&
-                        !!watch(quoteAuthor) &&
-                        getFieldState(exampleSentence).isTouched
-                    ) {
-                        return "Language is required when root specified";
-                    } else if (!watch(quoteAuthor) && value) {
-                        setError(quoteAuthor, {
-                            message: "Example sentence is required when author is selected",
-                        });
-                        return true;
-                    } else {
-                        clearErrors(quoteAuthor);
-                        return true;
-                    }
-                },
+                validate: (sentence => {
+                    const authorFormName = `meanings.${index}.example.author` as const
+                    const author = watch(authorFormName)
+                    if (author && !sentence) return "Example sentence is required when author is selected!"
+                    else return true
+                })
             }}
-            render={({ field }) => (
+            render={({ field, formState: { errors } }) => (
                 <>
                     <Input
                         {...field}
@@ -55,11 +33,7 @@ export default function MeaningExampleSentenceInput({
                         label="Example Sentence"
                         labelPlacement='outside'
                         isInvalid={!!errors?.meanings?.[index]?.example?.sentence}
-                        classNames={{
-                            description: clsx({
-                                'text-danger ease-out duration-200': errors?.meanings?.[index]?.example?.sentence
-                            })
-                        }}
+                        errorMessage={errors.meanings?.[index]?.example?.sentence?.message}
                         description="Example sentence is optional but required when example author is specified."
                     />
                 </>

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ImageInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/ImageInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { WordForm } from '@/types';
 import { Button } from '@nextui-org/react';
 import React, { ChangeEvent } from 'react'

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/PartOfSpeechInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/PartOfSpeechInput.tsx
@@ -29,8 +29,9 @@ export default function MeaningPartOfSpeechInput({
             render={({ field, fieldState: { error, isDirty } }) => (
                 <Select
                     label="Part of Speech"
-                    color="primary"
-                    variant="underlined"
+                    labelPlacement='outside'
+                    placeholder='Please select a part of speech for this meaning'
+                    description="Part of speech is required"
                     isRequired
                     isInvalid={error !== undefined && isDirty}
                     errorMessage={isDirty && error?.message}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/PartOfSpeechInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/PartOfSpeechInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { Select, SelectItem } from '@nextui-org/react'
 import React from 'react'
 import { Control, Controller } from 'react-hook-form'

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/WordMeaningInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/WordMeaningInput.tsx
@@ -24,9 +24,9 @@ export default function WordMeaningInput({
             render={({ field, fieldState: { error } }) => (
                 <Input
                     {...field}
+                    radius='sm'
                     label="Meaning"
-                    color="primary"
-                    variant="underlined"
+                    labelPlacement='outside'
                     description="Meaning is required."
                     isRequired
                     errorMessage={error?.message}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/WordMeaningInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Meaning/WordMeaningInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { WordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/NameInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/NameInput.tsx
@@ -30,9 +30,10 @@ export default function WordNameInput({
             render={({ field, fieldState: { error } }) => (
                 <Input
                     {...field}
+                    radius='sm'
                     label="Name"
-                    color="primary"
-                    variant="underlined"
+                    labelPlacement='outside'
+                    description="Name is required"
                     errorMessage={error?.message}
                     isInvalid={error !== undefined}
                     isRequired={true}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/NameInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/NameInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { api } from '@/src/trpc/react';
 import { WordForm } from '@/types';
 import { Input } from '@nextui-org/react';

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PhoneticInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PhoneticInput.tsx
@@ -15,9 +15,9 @@ export default function WordPhoneticInput({
             render={({ field, fieldState: { error } }) => (
                 <Input
                     {...field}
+                    radius='sm'
                     label="Phonetic"
-                    color="primary"
-                    variant="underlined"
+                    labelPlacement='outside'
                     description="Phonetics is optional"
                 />
             )}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PhoneticInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PhoneticInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { WordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PrefixInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PrefixInput.tsx
@@ -15,9 +15,9 @@ export default function WordPrefixInput({
             render={({ field }) => (
                 <Input
                     {...field}
+                    radius='sm'
                     label="Prefix"
-                    color="primary"
-                    variant="underlined"
+                    labelPlacement='outside'
                     description="Prefix is optional"
                 />
             )}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PrefixInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/PrefixInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { WordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootLanguageInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootLanguageInput.tsx
@@ -50,6 +50,8 @@ export default function WordRootLanguageInput({
                 <Autocomplete
                     radius='sm'
                     placeholder="You can search for a language"
+                    description="The root language is required when root is specified!"
+                    labelPlacement='outside'
                     isLoading={isLoading}
                     defaultItems={isSuccess ? langs : []}
                     label="Select an language"

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootLanguageInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootLanguageInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { api } from '@/src/trpc/react';
 import { WordForm } from '@/types';
 import { Autocomplete, AutocompleteItem } from '@nextui-org/react';

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootOriginInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootOriginInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { WordForm } from '@/types';
 import { Input } from '@nextui-org/react';
 import { useTranslations } from 'next-intl';

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootOriginInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/RootOriginInput.tsx
@@ -43,13 +43,13 @@ export default function WordRootOriginInput({
             }}
             render={({ field, fieldState: { error } }) => (
                 <Input
-                    placeholder="Type the root word"
+                    {...field}
+                    radius='sm'
                     label="Root"
-                    color="primary"
-                    variant="underlined"
+                    labelPlacement='outside'
+                    description={"The root is required when root language selected!"}
                     errorMessage={error?.message}
                     isInvalid={error !== undefined}
-                    {...field}
                 />
             )}
         />

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/SuffixInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/SuffixInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { WordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/SuffixInput.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/SuffixInput.tsx
@@ -15,9 +15,9 @@ export default function WordSuffixInput({
             render={({ field }) => (
                 <Input
                     {...field}
+                    radius='sm'
                     label="Suffix"
-                    color="primary"
-                    variant="underlined"
+                    labelPlacement='outside'
                     description="Suffix is optional"
                 />
             )}

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/WordAttributes.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/WordAttributes.tsx
@@ -1,18 +1,17 @@
 "use client"
+import AddWordAttributeModal from '@/src/components/customs/Modals/AddWordAttribute'
 import { api } from '@/src/trpc/react'
 import { WordForm } from '@/types'
-import { Button, Select, Selection, SelectItem } from '@nextui-org/react'
+import { Button, Select, Selection, SelectItem, useDisclosure } from '@nextui-org/react'
 import { Plus, X } from 'lucide-react'
 import React from 'react'
 import { Control, Controller, UseFormSetValue } from 'react-hook-form'
 
 export default function WordAttributesInput({
     control,
-    onOpen,
     setValue: setFieldValue
 }: {
     control: Control<WordForm>,
-    onOpen: () => void
     setValue: UseFormSetValue<WordForm>
 }) {
     const { data: wordAttributes, isLoading, isFetching, isRefetching } = api.admin.getWordAttributes.useQuery()
@@ -23,63 +22,67 @@ export default function WordAttributesInput({
         setValues(() => new Set(selectedAttributes))
         setFieldValue("attributes", selectedAttributes)
     };
+    const { isOpen, onOpenChange, onOpen, onClose } = useDisclosure()
     return (
-        <Controller
-            name={`attributes`}
-            control={control}
-            render={({ field, fieldState: { error } }) => (
-                <Select
-                    classNames={{
-                        trigger: "pl-1",
-                    }}
-                    radius='sm'
-                    as={'div'}
-                    tabIndex={0}
-                    placeholder='Select an attribute...'
-                    label='Attribute'
-                    labelPlacement='outside'
-                    selectedKeys={values}
-                    isLoading={isLoading || isFetching || isRefetching}
-                    isInvalid={error !== undefined} errorMessage={error?.message}
-                    {...field}
-                    onChange={handleSelectionChange}
-                    startContent={(
-                        <Button
-                            variant='light'
-                            isIconOnly
-                            color='danger'
-                            onPress={() => {
-                                setValues(new Set([]));
-                                setFieldValue("attributes", [])
-                            }}
-                        >
-                            <X aria-description='Reset all selected values button' />
-                            <div className='sr-only'>
-                                Reset selected values
-                            </div>
-                        </Button>
-                    )}
-                    endContent={(
-                        <Button
-                            isIconOnly
-                            onPress={onOpen}
-                            variant='light'
-                        >
-                            <Plus></Plus>
-                            <div className='sr-only'>
-                                Add new word attribute
-                            </div>
-                        </Button>
-                    )}
-                    selectionMode='multiple'>
-                    {wordAttributes?.map((wordAttribute => (
-                        <SelectItem key={wordAttribute.id}>
-                            {wordAttribute.attribute}
-                        </SelectItem>
-                    ))) ?? []}
-                </Select>
-            )
-            }
-        />
+        <>
+            <AddWordAttributeModal isOpen={isOpen} onClose={onClose} onOpenChange={onOpenChange} />
+            <Controller
+                name={`attributes`}
+                control={control}
+                render={({ field, fieldState: { error } }) => (
+                    <Select
+                        classNames={{
+                            trigger: "pl-1",
+                        }}
+                        radius='sm'
+                        as={'div'}
+                        tabIndex={0}
+                        placeholder='Select an attribute...'
+                        label='Attribute'
+                        labelPlacement='outside'
+                        selectedKeys={values}
+                        isLoading={isLoading || isFetching || isRefetching}
+                        isInvalid={error !== undefined} errorMessage={error?.message}
+                        {...field}
+                        onChange={handleSelectionChange}
+                        startContent={(
+                            <Button
+                                variant='light'
+                                isIconOnly
+                                color='danger'
+                                onPress={() => {
+                                    setValues(new Set([]));
+                                    setFieldValue("attributes", [])
+                                }}
+                            >
+                                <X aria-description='Reset all selected values button' />
+                                <div className='sr-only'>
+                                    Reset selected values
+                                </div>
+                            </Button>
+                        )}
+                        endContent={(
+                            <Button
+                                isIconOnly
+                                onPress={onOpen}
+                                variant='light'
+                            >
+                                <Plus></Plus>
+                                <div className='sr-only'>
+                                    Add new word attribute
+                                </div>
+                            </Button>
+                        )}
+                        selectionMode='multiple'>
+                        {wordAttributes?.map((wordAttribute => (
+                            <SelectItem key={wordAttribute.id}>
+                                {wordAttribute.attribute}
+                            </SelectItem>
+                        ))) ?? []}
+                    </Select>
+                )
+                }
+            />
+        </>
     )
 }

--- a/src/_pages/Dashboard/CreateWordForm/Inputs/Word/WordAttributes.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/Inputs/Word/WordAttributes.tsx
@@ -30,10 +30,14 @@ export default function WordAttributesInput({
             render={({ field, fieldState: { error } }) => (
                 <Select
                     classNames={{
-                        trigger: "pl-1 h-12 min-h-12",
+                        trigger: "pl-1",
                     }}
+                    radius='sm'
+                    as={'div'}
+                    tabIndex={0}
                     placeholder='Select an attribute...'
-                    as={"div"}
+                    label='Attribute'
+                    labelPlacement='outside'
                     selectedKeys={values}
                     isLoading={isLoading || isFetching || isRefetching}
                     isInvalid={error !== undefined} errorMessage={error?.message}
@@ -54,13 +58,12 @@ export default function WordAttributesInput({
                                 Reset selected values
                             </div>
                         </Button>
-
                     )}
                     endContent={(
                         <Button
                             isIconOnly
                             onPress={onOpen}
-                            color='primary'
+                            variant='light'
                         >
                             <Plus></Plus>
                             <div className='sr-only'>

--- a/src/_pages/Dashboard/CreateWordForm/MeaningFieldArrayButtons.tsx
+++ b/src/_pages/Dashboard/CreateWordForm/MeaningFieldArrayButtons.tsx
@@ -1,4 +1,5 @@
-import { Meaning, MeaningInputs, WordForm } from '@/types';
+"use client"
+import { Meaning, WordForm } from '@/types';
 import { Button, ButtonGroup } from '@nextui-org/react';
 import React from 'react'
 import { UseFieldArrayAppend, UseFieldArrayPrepend } from 'react-hook-form';

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Meaning/AuthorInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Meaning/AuthorInput.tsx
@@ -1,5 +1,4 @@
 import AddAuthorModal from '@/src/components/customs/Modals/AddAuthor'
-import AddAuthor from '@/src/components/customs/Modals/AddAuthor'
 import { EditWordForm } from '@/types'
 import { Button, Select, Selection, SelectItem, useDisclosure } from '@nextui-org/react'
 import { Plus } from 'lucide-react'
@@ -25,9 +24,9 @@ export default function AuthorInput({
     const { isOpen, onOpenChange, onOpen, onClose } = useDisclosure()
     const [value, setValue] = React.useState<Selection>(new Set(selectedAuthor));
     const handleSelectionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const selectedAttributes = e.target.value
-        setValue(() => new Set(selectedAttributes))
-        setFieldValue(`meanings.${index}.authorId`, selectedAttributes)
+        const selectedAuthor = e.target.value
+        setValue(() => new Set(selectedAuthor))
+        setFieldValue(`meanings.${index}.authorId`, selectedAuthor)
     };
 
     return (

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Meaning/AuthorInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Meaning/AuthorInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import AddAuthorModal from '@/src/components/customs/Modals/AddAuthor'
 import { EditWordForm } from '@/types'
 import { Button, Select, Selection, SelectItem, useDisclosure } from '@nextui-org/react'

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordLanguageInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordLanguageInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { EditWordForm, Language } from '@/types'
 import { Autocomplete, AutocompleteItem, Select, SelectItem } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordNameInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordNameInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { EditWordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordPhoneticInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordPhoneticInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { EditWordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordPrefixInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordPrefixInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { EditWordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordRootInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordRootInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { EditWordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordSuffixInput.tsx
+++ b/src/_pages/Dashboard/WordList/EditModal/Inputs/Word/WordSuffixInput.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { EditWordForm } from '@/types'
 import { Input } from '@nextui-org/react'
 import React from 'react'

--- a/src/app/[locale]/dashboard/create-word/page.tsx
+++ b/src/app/[locale]/dashboard/create-word/page.tsx
@@ -7,8 +7,16 @@ export default async function Page({
 }: {
   params: { locale: string };
 }) {
-  const meaningAttributes = await api.admin.getMeaningAttributes()
-  const authors = await api.admin.getExampleSentenceAuthors()
-  const partOfSpeeches = await api.admin.getPartOfSpeeches();
+  const meaningAttributesPromise = api.admin.getMeaningAttributes()
+  const authorsPromise = api.admin.getExampleSentenceAuthors()
+  const partOfSpeechesPromise = api.admin.getPartOfSpeeches();
+  const results = await Promise.allSettled([meaningAttributesPromise, authorsPromise, partOfSpeechesPromise])
+  const meaningAttributes = results[0].status === "fulfilled" ? results[0].value : []
+  const authors = results[1].status === "fulfilled" ? results[1].value.map((author) => ({
+    ...author,
+    id: author.id.toString(),
+  })) : []
+  const partOfSpeeches = results[2].status === "fulfilled" ? results[2].value : []
+
   return <CreateWord locale={locale} meaningAttributes={meaningAttributes} authors={authors} partOfSpeeches={partOfSpeeches} />;
 }

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -161,7 +161,11 @@ export const adminRouter = createTRPCRouter({
       id: authors.id,
       name: authors.name
     }).from(authors)
-    return authorsData
+    const filteredAuthors = authorsData.map((author) => ({
+      ...author,
+      id: author.id.toString()
+    }))
+    return filteredAuthors
   }),
   getPartOfSpeeches: adminProcedure.query(async ({ ctx: { db } }) => {
     const partOfSpeechData = await db.select({ id: partOfSpeechs.id, partOfSpeech: partOfSpeechs.partOfSpeech }).from(partOfSpeechs)

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,7 +46,7 @@ type Meaning = {
   image: FileList | null;
   example?: {
     sentence: string | undefined;
-    author: string | undefined;
+    author?: string | undefined;
   };
   partOfSpeechId: number | undefined;
   attributes: string[];
@@ -74,7 +74,7 @@ type WordFormSubmit = Prettify<{
     attributes: number[];
     example?: {
       sentence: string;
-      author: 'string | number';
+      author?: number | undefined;
     }
   }[]
 }>;


### PR DESCRIPTION
This pull request includes refactoring of the word inputs, where the variants are set to default and the labelPlacement is set to outside. It also fixes the issue of tabbing through meaning inputs. Additionally, missing small radius values in inputs are set. The author component has been replaced with a new SelectComponent approach as in edit modals, and the addWord endpoint has been updated. Input validations for the example sentence and author have been renewed by avoiding sending the author without an example sentence since it doesn't make sense. The author query has been added to revalidate when a new one is added. The "use client" directive has been added to the files that were missing it.