### PR TITLE
add: initial robots.txt to disallow GPTBot make request like a DDOS a…

### DIFF
--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /dashboard
+
+User-agent: GPTBot
+Disallow: /


### PR DESCRIPTION
Trying to find a solution to this: 
![image](https://github.com/user-attachments/assets/631b99dc-4ae8-4a42-a83b-d049ac08b031)

GPTBot trying to crawl the dictionary on development and ruined my vercel usage.