### PR TITLE
fix: languages Autocomplete search filter

### DIFF
--- a/src/components/customs/edit-request-modal/word-edit-request.tsx
+++ b/src/components/customs/edit-request-modal/word-edit-request.tsx
@@ -130,11 +130,10 @@ export default function WordEditRequest({
           <Autocomplete
             radius='sm'
             {...field}
-            isVirtualized
             label="Language"
             isLoading={languagesIsLoading}
             labelPlacement='outside'
-            items={languages || []}
+            defaultItems={languages || []}
             placeholder="Select Language"
             defaultSelectedKey={word_data.root.language_code}
             onSelectionChange={(item) => {


### PR DESCRIPTION
- the reason why it didn't work was items prop was used instead of defaultItems