### PR TITLE
Fix Turkish dashboard canonical route mappings

### DIFF
--- a/src/i18n/pathnames.ts
+++ b/src/i18n/pathnames.ts
@@ -113,23 +113,23 @@ export const pathnames = {
   },
   "/dashboard/announcements": {
     en: "/dashboard/announcements",
-    tr: "/dashboard/duyurular",
+    tr: "/panel/duyurular",
   },
   "/dashboard/announcements/new": {
     en: "/dashboard/announcements/new",
-    tr: "/dashboard/duyurular/yeni",
+    tr: "/panel/duyurular/yeni",
   },
   "/dashboard/announcements/[id]/edit": {
     en: "/dashboard/announcements/[id]/edit",
-    tr: "/dashboard/duyurular/[id]/duzenle",
+    tr: "/panel/duyurular/[id]/duzenle",
   },
   "/dashboard/daily-words": {
     en: "/dashboard/daily-words",
-    tr: "/dashboard/gundelik-kelimeler",
+    tr: "/panel/gundelik-kelimeler",
   },
   "/dashboard/daily-words/[id]/edit": {
     en: "/dashboard/daily-words/[id]/edit",
-    tr: "/dashboard/gundelik-kelimeler/[id]/duzenle",
+    tr: "/panel/gundelik-kelimeler/[id]/duzenle",
   },
   "/dashboard/badges": {
     en: "/dashboard/badges",

--- a/src/lib/__tests__/seo-utils.test.ts
+++ b/src/lib/__tests__/seo-utils.test.ts
@@ -29,7 +29,16 @@ describe("seo-utils", () => {
   it("builds Turkish canonical paths for static and word pages", () => {
     expect(getStaticRouteCanonicalPath("/", "tr")).toBe("/tr");
     expect(getStaticRouteCanonicalPath("/word-list", "tr")).toBe("/tr/kelime-listesi");
+    expect(getStaticRouteCanonicalPath("/dashboard/announcements", "tr")).toBe("/tr/panel/duyurular");
     expect(getWordCanonicalPath("boncukluk", "tr")).toBe("/tr/arama/boncukluk");
+  });
+
+  it("redirects the mistaken Turkish dashboard aliases added by the SEO routing refactor", () => {
+    expect(getCanonicalPathname("/dashboard/duyurular")).toBe("/tr/panel/duyurular");
+    expect(getCanonicalPathname("/tr/dashboard/duyurular")).toBe("/tr/panel/duyurular");
+    expect(getCanonicalPathname("/tr/dashboard/gundelik-kelimeler/42/duzenle")).toBe(
+      "/tr/panel/gundelik-kelimeler/42/duzenle",
+    );
   });
 
   it("matches and interpolates route templates", () => {

--- a/src/lib/seo-utils.ts
+++ b/src/lib/seo-utils.ts
@@ -170,17 +170,38 @@ type RedirectCandidate = {
     target: string;
 };
 
+type ExtraRedirectMap = Partial<Record<RouteKey, readonly string[]>>;
+
+const EXTRA_TURKISH_DASHBOARD_REDIRECTS: ExtraRedirectMap = {
+    "/dashboard/announcements": ["/dashboard/duyurular", "/tr/dashboard/duyurular"],
+    "/dashboard/announcements/new": ["/dashboard/duyurular/yeni", "/tr/dashboard/duyurular/yeni"],
+    "/dashboard/announcements/[id]/edit": [
+        "/dashboard/duyurular/[id]/duzenle",
+        "/tr/dashboard/duyurular/[id]/duzenle",
+    ],
+    "/dashboard/daily-words": ["/dashboard/gundelik-kelimeler", "/tr/dashboard/gundelik-kelimeler"],
+    "/dashboard/daily-words/[id]/edit": [
+        "/dashboard/gundelik-kelimeler/[id]/duzenle",
+        "/tr/dashboard/gundelik-kelimeler/[id]/duzenle",
+    ],
+};
+
 function getRedirectCandidates(routeKey: RouteKey): RedirectCandidate[] {
     const trTemplate = getExternalPathTemplate(routeKey, "tr");
     const enTemplate = getExternalPathTemplate(routeKey, "en");
     const canonicalTrTemplate = prefixLocalePath("tr", trTemplate);
     const canonicalEnTemplate = prefixLocalePath("en", enTemplate);
+    const extraTurkishTemplates: readonly string[] = EXTRA_TURKISH_DASHBOARD_REDIRECTS[routeKey] ?? [];
 
     return [
         { template: trTemplate, target: canonicalTrTemplate },
         { template: enTemplate, target: canonicalTrTemplate },
         { template: prefixLocalePath("tr", enTemplate), target: canonicalTrTemplate },
         { template: prefixLocalePath("en", trTemplate), target: canonicalEnTemplate },
+        ...extraTurkishTemplates.map((template) => ({
+            template,
+            target: canonicalTrTemplate,
+        })),
     ];
 }
 


### PR DESCRIPTION
## Summary
- correct Turkish dashboard path mappings to use the `/panel/...` canonical URLs
- preserve redirects from the mistakenly shipped `/dashboard/...` Turkish aliases
- add regression coverage for canonical dashboard paths and redirect behavior
- tighten redirect-map typing in `seo-utils`

## Testing
- Not run (not requested)