### PR TITLE
Fix repeated fetching on the word list page

### DIFF
--- a/src/_pages/word-list/word-list.tsx
+++ b/src/_pages/word-list/word-list.tsx
@@ -87,15 +87,27 @@ export default function WordList() {
 
     const debouncedSearch = useDebounce(watch("search"), 500);
     const isFirstRender = useRef(true);
+    const didInitializeFilterReset = useRef(false);
+    const skipNextUrlSync = useRef(false);
+    const searchParamsString = searchParams.toString();
 
     // reset to first page when search changes
     useEffect(() => {
+        if (skipNextUrlSync.current) return;
+
+        if (!didInitializeFilterReset.current) {
+            didInitializeFilterReset.current = true;
+            return;
+        }
+
         setPageNumber(1);
     }, [debouncedSearch, selectedPos, selectedLang, selectedAttr, sortBy, sortOrder, selectedLetter, viewMode]);
 
     // update state on URL param changes (back/forward)
     useEffect(() => {
         if (isFirstRender.current) return;
+        skipNextUrlSync.current = true;
+
         const paramPage = Number(searchParams.get('page')) || 1;
         const paramPer = Number(searchParams.get('per_page')) || 10;
 
@@ -121,7 +133,7 @@ export default function WordList() {
 
         setValue('search', paramSearch, { shouldDirty: false });
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [searchParams, setValue]);
+    }, [searchParamsString, setValue]);
 
     // sync state to URL, enable back/forward history
     useEffect(() => {
@@ -129,6 +141,12 @@ export default function WordList() {
             isFirstRender.current = false;
             return;
         }
+
+        if (skipNextUrlSync.current) {
+            skipNextUrlSync.current = false;
+            return;
+        }
+
         const params = new URLSearchParams();
         if (debouncedSearch) params.set('search', debouncedSearch);
         if (selectedPos.length > 0) params.set('pos', selectedPos.join(','));
@@ -141,8 +159,12 @@ export default function WordList() {
 
         params.set('page', pageNumber.toString());
         params.set('per_page', wordsPerPage.toString());
-        router.push(`${pathname}?${params.toString()}`);
-    }, [pageNumber, wordsPerPage, debouncedSearch, selectedPos, selectedLang, selectedAttr, sortBy, sortOrder, selectedLetter, viewMode, pathname, router]);
+        const nextSearch = params.toString();
+
+        if (nextSearch === searchParamsString) return;
+
+        router.push(`${pathname}?${nextSearch}`);
+    }, [pageNumber, wordsPerPage, debouncedSearch, selectedPos, selectedLang, selectedAttr, sortBy, sortOrder, selectedLetter, viewMode, pathname, router, searchParamsString]);
 
     const { data: wordCount } = api.word.getWordCount.useQuery({
         search: debouncedSearch,

--- a/src/hooks/use-progress-router.ts
+++ b/src/hooks/use-progress-router.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useMemo } from "react";
 import { useRouter as useNextRouter } from "next/navigation";
 
 import { startNavigationProgress } from "@/src/lib/navigation-progress";
@@ -29,33 +30,52 @@ function shouldStartForStringHref(href: string) {
 export function useProgressRouter() {
   const router = useNextRouter();
 
-  return {
-    ...router,
-    push(href: string, options?: Parameters<typeof router.push>[1]) {
+  const push = useCallback(
+    (href: string, options?: Parameters<typeof router.push>[1]) => {
       if (shouldStartForStringHref(href)) {
         startNavigationProgress();
       }
 
       return router.push(href, options);
     },
-    replace(href: string, options?: Parameters<typeof router.replace>[1]) {
+    [router],
+  );
+
+  const replace = useCallback(
+    (href: string, options?: Parameters<typeof router.replace>[1]) => {
       if (shouldStartForStringHref(href)) {
         startNavigationProgress();
       }
 
       return router.replace(href, options);
     },
-    back() {
-      startNavigationProgress();
-      return router.back();
-    },
-    forward() {
-      startNavigationProgress();
-      return router.forward();
-    },
-    refresh() {
-      startNavigationProgress();
-      return router.refresh();
-    },
-  };
+    [router],
+  );
+
+  const back = useCallback(() => {
+    startNavigationProgress();
+    return router.back();
+  }, [router]);
+
+  const forward = useCallback(() => {
+    startNavigationProgress();
+    return router.forward();
+  }, [router]);
+
+  const refresh = useCallback(() => {
+    startNavigationProgress();
+    return router.refresh();
+  }, [router]);
+
+  return useMemo(
+    () => ({
+      ...router,
+      push,
+      replace,
+      back,
+      forward,
+      refresh,
+    }),
+    [router, push, replace, back, forward, refresh],
+  );
 }


### PR DESCRIPTION
## Summary
- prevent the word list from pushing the same query string back into the router
- skip the initial page-reset cycle so URL hydration does not trigger another navigation
- stabilize the progress router wrapper so dependent effects do not retrigger unnecessarily

## Testing
- `npx tsc --noEmit`
- local validation of the word list URL/state sync path