### PR TITLE
Add donation page for GitHub Sponsors and Patreon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+## UI Styling
+
+- For every new page or component, use `bg-background/40` for main surfaces and section backgrounds by default so the site-wide red background gradient remains visible.
+- Do not replace the shared red background gradient with page-local gradients unless the user explicitly asks for a gradient.
+- Use solid or translucent Tailwind background utilities over custom gradient utilities for routine UI surfaces.

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,6 +21,7 @@
     "ariaBlur": "Toggle Blur Efects",
     "Contribute": "Contribute",
     "Feedback": "Feedback",
+    "Donate": "Donate",
     "Search": "Search",
     "OfflineDictionary": "Offline Dictionary",
     "ForeignTermSuggestions": "Foreign Term Suggestions",
@@ -352,6 +353,7 @@
       "announcements": "Announcements",
       "seeFeedback": "See Feedback",
       "contributeWord": "Contribute Word",
+      "donate": "Donate",
       "pronunciations": "Pronunciations",
       "privacy": "Privacy Policy",
       "terms": "Terms of Service",
@@ -361,6 +363,32 @@
       "leaderboards": "Leaderboards",
       "foreignTermSuggestions": "Foreign Term Suggestions"
     }
+  },
+  "Donation": {
+    "metaTitle": "Support Turkish Dictionary",
+    "metaDescription": "Support the open-source Turkish Dictionary through GitHub Sponsors or Patreon.",
+    "eyebrow": "Open-source language work",
+    "title": "Keep Turkish Dictionary free, fast, and community-run.",
+    "subtitle": "Your support helps cover the infrastructure and maintenance behind the dictionary, games, offline data, and contribution tools.",
+    "githubCta": "Sponsor on GitHub",
+    "patreonCta": "Support on Patreon",
+    "patreonUnavailable": "Patreon coming soon",
+    "visualLabel": "Project health",
+    "visualTitle": "Sustained by the community",
+    "visualNoteLabel": "Payment handling",
+    "visualNote": "External sponsor platforms only",
+    "supportEyebrow": "What donations support",
+    "supportTitle": "Small contributions keep the service useful.",
+    "supportDescription": "Donations go toward the practical parts of running a public dictionary and keeping it pleasant to use.",
+    "supportItems": [
+      "Hosting and database costs",
+      "Search infrastructure",
+      "Offline dictionary data",
+      "Maintenance and moderation",
+      "Community features"
+    ],
+    "finalTitle": "Choose the platform that works for you.",
+    "externalNote": "Turkish Dictionary does not process payments directly. GitHub Sponsors and Patreon handle checkout, receipts, currencies, and payment security on their own websites."
   },
   "SigninForm": {
     "Sign in with Google": "Sign in with Google",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -21,6 +21,7 @@
     "ariaBlur": "Blur Etkilerini Açma/Kapatma Butonu",
     "Contribute": "Katkıda Bulun",
     "Feedback": "Geri Bildirim",
+    "Donate": "Destek Ol",
     "Search": "Ara",
     "OfflineDictionary": "Çevrim Dışı Sözlük",
     "FlashcardGame": "Kelime Kartları",
@@ -354,6 +355,7 @@
       "privacy": "Gizlilik Politikası",
       "terms": "Kullanım Şartları",
       "contributeWord": "Kelime Katkısı",
+      "donate": "Destek Ol",
       "pronunciations": "Telaffuzlar",
       "flashcardGame": "Kelime Kartları Oyunu",
       "wordMatchingGame": "Kelime Eşleştirme",
@@ -361,6 +363,32 @@
       "leaderboards": "Sıralama Tabloları",
       "foreignTermSuggestions": "Yabancı Terim Önerileri"
     }
+  },
+  "Donation": {
+    "metaTitle": "Türkçe Sözlük'e Destek Ol",
+    "metaDescription": "Açık kaynak Türkçe Sözlük'ü GitHub Sponsors veya Patreon üzerinden destekleyin.",
+    "eyebrow": "Açık kaynak dil çalışması",
+    "title": "Türkçe Sözlük ücretsiz, hızlı ve toplulukla gelişen bir kaynak olarak kalsın.",
+    "subtitle": "Desteğiniz sözlüğün, oyunların, çevrim dışı verilerin ve katkı araçlarının arkasındaki altyapı ve bakım giderlerine katkı sağlar.",
+    "githubCta": "GitHub'da sponsor ol",
+    "patreonCta": "Patreon'da destek ol",
+    "patreonUnavailable": "Patreon yakında",
+    "visualLabel": "Proje sağlığı",
+    "visualTitle": "Topluluk desteğiyle sürüyor",
+    "visualNoteLabel": "Ödeme yöntemi",
+    "visualNote": "Yalnızca harici destek platformları",
+    "supportEyebrow": "Bağışlar neyi destekler",
+    "supportTitle": "Küçük katkılar hizmeti kullanılabilir tutar.",
+    "supportDescription": "Bağışlar herkese açık bir sözlüğü çalıştırmanın ve kullanımı keyifli tutmanın pratik giderlerine katkı sağlar.",
+    "supportItems": [
+      "Hosting ve veritabanı giderleri",
+      "Arama altyapısı",
+      "Çevrim dışı sözlük verisi",
+      "Bakım ve moderasyon",
+      "Topluluk özellikleri"
+    ],
+    "finalTitle": "Size uygun platformu seçin.",
+    "externalNote": "Türkçe Sözlük ödemeleri doğrudan işlemez. GitHub Sponsors ve Patreon ödeme adımlarını, makbuzları, para birimlerini ve ödeme güvenliğini kendi sitelerinde yönetir."
   },
   "SigninForm": {
     "Sign in with Google": "Google ile Giriş Yap",

--- a/src/app/[locale]/donate/donation-page-client.tsx
+++ b/src/app/[locale]/donate/donation-page-client.tsx
@@ -33,8 +33,8 @@ export default function DonationPageClient({
   const supportItems = t.raw("supportItems") as string[];
 
   return (
-    <div className="w-full overflow-hidden bg-background">
-      <section className="relative min-h-[calc(100svh-4rem)] w-full border-b border-border/60 bg-background">
+    <div className="w-full overflow-hidden bg-background/40">
+      <section className="relative min-h-[calc(100svh-4rem)] w-full border-b border-border/60 bg-background/40">
         <div className="mx-auto grid min-h-[calc(100svh-4rem)] w-full max-w-7xl grid-cols-1 items-center gap-12 px-5 py-16 sm:px-8 lg:grid-cols-[minmax(0,1fr)_420px] lg:px-10">
           <motion.div
             initial={{ opacity: 0, y: 18 }}
@@ -42,7 +42,7 @@ export default function DonationPageClient({
             transition={{ duration: 0.45, ease: "easeOut" }}
             className="max-w-3xl"
           >
-            <div className="mb-7 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-background px-3 py-2 text-sm font-medium text-primary shadow-sm">
+            <div className="mb-7 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-background/40 px-3 py-2 text-sm font-medium text-primary shadow-sm">
               <HandHeart className="h-4 w-4" />
               {t("eyebrow")}
             </div>
@@ -101,7 +101,7 @@ export default function DonationPageClient({
             className="relative hidden lg:block"
             aria-hidden="true"
           >
-            <div className="aspect-[4/5] rounded-md border border-border/70 bg-background p-7 shadow-2xl">
+            <div className="aspect-[4/5] rounded-md border border-border/70 bg-background/40 p-7 shadow-2xl">
               <div className="flex h-full flex-col justify-between">
                 <div>
                   <div className="flex items-center justify-between border-b border-border/70 pb-5">
@@ -166,7 +166,7 @@ export default function DonationPageClient({
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-80px" }}
                   transition={{ delay: index * 0.04, duration: 0.35 }}
-                  className="flex items-center gap-4 rounded-md border border-border/70 bg-background px-4 py-4"
+                  className="flex items-center gap-4 rounded-md border border-border/70 bg-background/40 px-4 py-4"
                 >
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
                     <Icon className="h-5 w-5" />
@@ -179,7 +179,7 @@ export default function DonationPageClient({
         </div>
       </section>
 
-      <section className="border-t border-border/60 bg-background">
+      <section className="border-t border-border/60 bg-background/40">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-5 py-12 sm:px-8 lg:flex-row lg:items-center lg:justify-between lg:px-10">
           <div className="max-w-2xl">
             <h2 className="text-2xl font-bold text-foreground">{t("finalTitle")}</h2>

--- a/src/app/[locale]/donate/donation-page-client.tsx
+++ b/src/app/[locale]/donate/donation-page-client.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { Button } from "@heroui/react";
+import { motion } from "framer-motion";
+import {
+  ArrowRight,
+  Database,
+  ExternalLink,
+  Github,
+  HandHeart,
+  HeartHandshake,
+  Search,
+  Server,
+  ShieldCheck,
+  Sparkles,
+  Users,
+  Wrench,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+
+type DonationPageClientProps = {
+  githubSponsorsUrl: string;
+  patreonUrl?: string;
+};
+
+const supportIcons = [Server, Search, Database, Wrench, Users] as const;
+
+export default function DonationPageClient({
+  githubSponsorsUrl,
+  patreonUrl,
+}: DonationPageClientProps) {
+  const t = useTranslations("Donation");
+  const supportItems = t.raw("supportItems") as string[];
+
+  return (
+    <div className="w-full overflow-hidden">
+      <section className="relative min-h-[calc(100svh-4rem)] w-full border-b border-border/60">
+        <div
+          className="absolute inset-0 -z-10 bg-[linear-gradient(135deg,rgba(169,17,1,0.22),rgba(17,24,39,0.08)_38%,rgba(234,179,8,0.12)_100%)]"
+          aria-hidden="true"
+        />
+        <div
+          className="absolute inset-y-0 right-0 -z-10 hidden w-1/2 bg-[radial-gradient(circle_at_center,rgba(169,17,1,0.28),transparent_62%)] lg:block"
+          aria-hidden="true"
+        />
+
+        <div className="mx-auto grid min-h-[calc(100svh-4rem)] w-full max-w-7xl grid-cols-1 items-center gap-12 px-5 py-16 sm:px-8 lg:grid-cols-[minmax(0,1fr)_420px] lg:px-10">
+          <motion.div
+            initial={{ opacity: 0, y: 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut" }}
+            className="max-w-3xl"
+          >
+            <div className="mb-7 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-background/70 px-3 py-2 text-sm font-medium text-primary shadow-sm backdrop-blur">
+              <HandHeart className="h-4 w-4" />
+              {t("eyebrow")}
+            </div>
+            <h1 className="max-w-4xl text-4xl font-bold leading-tight text-foreground sm:text-5xl lg:text-6xl">
+              {t("title")}
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+              {t("subtitle")}
+            </p>
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+              <Button
+                as="a"
+                href={githubSponsorsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="primary"
+                size="lg"
+                className="h-12 rounded-md px-5 font-semibold"
+                startContent={<Github className="h-5 w-5" />}
+                endContent={<ExternalLink className="h-4 w-4" />}
+              >
+                {t("githubCta")}
+              </Button>
+              {patreonUrl ? (
+                <Button
+                  as="a"
+                  href={patreonUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="bordered"
+                  size="lg"
+                  className="h-12 rounded-md border-primary/35 px-5 font-semibold"
+                  startContent={<HeartHandshake className="h-5 w-5" />}
+                  endContent={<ExternalLink className="h-4 w-4" />}
+                >
+                  {t("patreonCta")}
+                </Button>
+              ) : (
+                <Button
+                  isDisabled
+                  variant="bordered"
+                  size="lg"
+                  className="h-12 rounded-md border-default-300 px-5 font-semibold"
+                  startContent={<HeartHandshake className="h-5 w-5" />}
+                >
+                  {t("patreonUnavailable")}
+                </Button>
+              )}
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ delay: 0.1, duration: 0.45, ease: "easeOut" }}
+            className="relative hidden lg:block"
+            aria-hidden="true"
+          >
+            <div className="aspect-[4/5] rounded-md border border-border/70 bg-background/72 p-7 shadow-2xl shadow-primary/10 backdrop-blur-xl">
+              <div className="flex h-full flex-col justify-between">
+                <div>
+                  <div className="flex items-center justify-between border-b border-border/70 pb-5">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground">
+                        <Sparkles className="h-5 w-5" />
+                      </div>
+                      <div>
+                        <p className="text-sm text-muted-foreground">{t("visualLabel")}</p>
+                        <p className="text-lg font-semibold">{t("visualTitle")}</p>
+                      </div>
+                    </div>
+                    <ShieldCheck className="h-6 w-6 text-success" />
+                  </div>
+                  <div className="space-y-4 pt-7">
+                    {supportItems.slice(0, 4).map((item, index) => {
+                      const Icon = supportIcons[index];
+                      return (
+                        <div key={item} className="flex items-center gap-3">
+                          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10 text-primary">
+                            <Icon className="h-4 w-4" />
+                          </div>
+                          <div className="h-2 flex-1 rounded-full bg-foreground/10">
+                            <div
+                              className="h-full rounded-full bg-primary/75"
+                              style={{ width: `${86 - index * 9}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="rounded-md bg-foreground p-5 text-background">
+                  <p className="text-sm font-medium opacity-75">{t("visualNoteLabel")}</p>
+                  <p className="mt-2 text-2xl font-bold">{t("visualNote")}</p>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-7xl px-5 py-16 sm:px-8 lg:px-10 lg:py-20">
+        <div className="grid gap-10 lg:grid-cols-[360px_minmax(0,1fr)] lg:items-start">
+          <div>
+            <p className="text-sm font-semibold uppercase text-primary">{t("supportEyebrow")}</p>
+            <h2 className="mt-3 text-3xl font-bold text-foreground sm:text-4xl">
+              {t("supportTitle")}
+            </h2>
+            <p className="mt-4 text-base leading-7 text-muted-foreground">
+              {t("supportDescription")}
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {supportItems.map((item, index) => {
+              const Icon = supportIcons[index] ?? ArrowRight;
+              return (
+                <motion.div
+                  key={item}
+                  initial={{ opacity: 0, y: 14 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true, margin: "-80px" }}
+                  transition={{ delay: index * 0.04, duration: 0.35 }}
+                  className="flex items-center gap-4 rounded-md border border-border/70 bg-background/65 px-4 py-4 backdrop-blur"
+                >
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <p className="font-medium text-foreground">{item}</p>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-border/60 bg-background/70">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-5 py-12 sm:px-8 lg:flex-row lg:items-center lg:justify-between lg:px-10">
+          <div className="max-w-2xl">
+            <h2 className="text-2xl font-bold text-foreground">{t("finalTitle")}</h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">{t("externalNote")}</p>
+          </div>
+          <Button
+            as="a"
+            href={githubSponsorsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            color="primary"
+            size="lg"
+            className="h-12 rounded-md px-5 font-semibold"
+            startContent={<Github className="h-5 w-5" />}
+            endContent={<ExternalLink className="h-4 w-4" />}
+          >
+            {t("githubCta")}
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/[locale]/donate/donation-page-client.tsx
+++ b/src/app/[locale]/donate/donation-page-client.tsx
@@ -33,17 +33,8 @@ export default function DonationPageClient({
   const supportItems = t.raw("supportItems") as string[];
 
   return (
-    <div className="w-full overflow-hidden">
-      <section className="relative min-h-[calc(100svh-4rem)] w-full border-b border-border/60">
-        <div
-          className="absolute inset-0 -z-10 bg-[linear-gradient(135deg,rgba(169,17,1,0.22),rgba(17,24,39,0.08)_38%,rgba(234,179,8,0.12)_100%)]"
-          aria-hidden="true"
-        />
-        <div
-          className="absolute inset-y-0 right-0 -z-10 hidden w-1/2 bg-[radial-gradient(circle_at_center,rgba(169,17,1,0.28),transparent_62%)] lg:block"
-          aria-hidden="true"
-        />
-
+    <div className="w-full overflow-hidden bg-background">
+      <section className="relative min-h-[calc(100svh-4rem)] w-full border-b border-border/60 bg-background">
         <div className="mx-auto grid min-h-[calc(100svh-4rem)] w-full max-w-7xl grid-cols-1 items-center gap-12 px-5 py-16 sm:px-8 lg:grid-cols-[minmax(0,1fr)_420px] lg:px-10">
           <motion.div
             initial={{ opacity: 0, y: 18 }}
@@ -51,7 +42,7 @@ export default function DonationPageClient({
             transition={{ duration: 0.45, ease: "easeOut" }}
             className="max-w-3xl"
           >
-            <div className="mb-7 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-background/70 px-3 py-2 text-sm font-medium text-primary shadow-sm backdrop-blur">
+            <div className="mb-7 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-background px-3 py-2 text-sm font-medium text-primary shadow-sm">
               <HandHeart className="h-4 w-4" />
               {t("eyebrow")}
             </div>
@@ -110,7 +101,7 @@ export default function DonationPageClient({
             className="relative hidden lg:block"
             aria-hidden="true"
           >
-            <div className="aspect-[4/5] rounded-md border border-border/70 bg-background/72 p-7 shadow-2xl shadow-primary/10 backdrop-blur-xl">
+            <div className="aspect-[4/5] rounded-md border border-border/70 bg-background p-7 shadow-2xl">
               <div className="flex h-full flex-col justify-between">
                 <div>
                   <div className="flex items-center justify-between border-b border-border/70 pb-5">
@@ -175,7 +166,7 @@ export default function DonationPageClient({
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-80px" }}
                   transition={{ delay: index * 0.04, duration: 0.35 }}
-                  className="flex items-center gap-4 rounded-md border border-border/70 bg-background/65 px-4 py-4 backdrop-blur"
+                  className="flex items-center gap-4 rounded-md border border-border/70 bg-background px-4 py-4"
                 >
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
                     <Icon className="h-5 w-5" />
@@ -188,7 +179,7 @@ export default function DonationPageClient({
         </div>
       </section>
 
-      <section className="border-t border-border/60 bg-background/70">
+      <section className="border-t border-border/60 bg-background">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-5 py-12 sm:px-8 lg:flex-row lg:items-center lg:justify-between lg:px-10">
           <div className="max-w-2xl">
             <h2 className="text-2xl font-bold text-foreground">{t("finalTitle")}</h2>

--- a/src/app/[locale]/donate/page.tsx
+++ b/src/app/[locale]/donate/page.tsx
@@ -1,0 +1,37 @@
+import { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import DonationPageClient from "./donation-page-client";
+import { donationLinks } from "@/src/config/donation";
+
+type Props = {
+  params: Promise<{
+    locale: string;
+  }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Donation" });
+
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    openGraph: {
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+      type: "website",
+    },
+  };
+}
+
+export default async function DonatePage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <DonationPageClient
+      githubSponsorsUrl={donationLinks.githubSponsors}
+      patreonUrl={donationLinks.patreon}
+    />
+  );
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -204,6 +204,7 @@ export default async function RootLayout({
                     LogoutIntl={t("Logout")}
                     AnnouncementsIntl={t("Announcements")}
                     ContributeWordIntl={t("ContributeWord")}
+                    DonateIntl={t("Donate")}
                     PronunciationsIntl={t("Pronunciations")}
                     ariaAvatar={t("ariaAvatar")}
                     ariaMenu={t("ariaMenu")}

--- a/src/components/customs/footer.tsx
+++ b/src/components/customs/footer.tsx
@@ -26,6 +26,7 @@ export default async function Footer({ session }: { session: Session | null }) {
         ],
         community: [
             { href: "/contribute-word" as const, label: t("links.contributeWord") },
+            { href: "/donate" as const, label: t("links.donate") },
             { href: "/pronunciation-voting" as const, label: t("links.pronunciations") },
             { href: "/feedback" as const, label: t("links.seeFeedback") },
             { href: "/foreign-term-suggestions" as const, label: t("links.foreignTermSuggestions") },

--- a/src/components/customs/navbar-and-sidebar.tsx
+++ b/src/components/customs/navbar-and-sidebar.tsx
@@ -21,6 +21,7 @@ export default function NavbarAndSidebar({
     LogoutIntl,
     AnnouncementsIntl,
     ContributeWordIntl,
+    DonateIntl,
     PronunciationsIntl,
     ariaAvatar,
     ariaMenu,
@@ -51,6 +52,7 @@ export default function NavbarAndSidebar({
     LogoutIntl: string
     AnnouncementsIntl: string
     ContributeWordIntl: string
+    DonateIntl: string
     PronunciationsIntl: string,
     ariaAvatar: string,
     ariaMenu: string,
@@ -87,6 +89,7 @@ export default function NavbarAndSidebar({
                 LogoutIntl={LogoutIntl}
                 AnnouncementsIntl={AnnouncementsIntl}
                 ContributeWordIntl={ContributeWordIntl}
+                DonateIntl={DonateIntl}
                 PronunciationsIntl={PronunciationsIntl}
                 setIsSidebarOpen={setIsSidebarOpen}
                 ariaAvatar={ariaAvatar}

--- a/src/components/customs/navbar.tsx
+++ b/src/components/customs/navbar.tsx
@@ -11,7 +11,7 @@ import {
   NavbarBrand,
   DropdownSection
 } from "@heroui/react";
-import { Blocks, BookOpen, ChevronDown, GitPullRequestArrow, Globe, HandHeart, HeartHandshake, HistoryIcon, Languages, Layers, Link2, LogOut, Mic, Monitor, Moon, Search, StarIcon, Sun, UserIcon, Zap } from "lucide-react";
+import { Blocks, BookOpen, ChevronDown, GitPullRequestArrow, Globe, HandHeart, HeartHandshake, HistoryIcon, Languages, Layers, Link2, LogOut, Mic, Monitor, Moon, Search, StarIcon, Sun, UserIcon, WalletCards, Zap } from "lucide-react";
 import { Input } from "@heroui/input";
 // import { signIn, signOut } from "next-auth/react"; // Removed
 import { authClient, type User } from "@/src/lib/auth-client"; // Added
@@ -33,7 +33,7 @@ import { startNavigationProgress } from "@/src/lib/navigation-progress";
 
 type NavbarProps = {
   session: Session | null;
-} & Record<"TitleIntl" | "WordListIntl" | "WordBuilderIntl" | "SignInIntl" | "HomeIntl" | "ProfileIntl" | "SavedWordsIntl" | "MyRequestsIntl" | "SearchHistoryIntl" | "LogoutIntl" | "AnnouncementsIntl" | "ContributeWordIntl" | "PronunciationsIntl" | "ariaAvatar" | "ariaMenu" | "ariaLanguages" | "ariaSwitchTheme" | "ariaBlur" | "ContributeIntl" | "FeedbackIntl" | "LearnIntl" | "FlashcardGameIntl" | "WordMatchingGameIntl" | "SpeedRoundGameIntl" | "ForeignTermSuggestionsIntl" | "SearchIntl" | "DashboardIntl", string>;
+} & Record<"TitleIntl" | "WordListIntl" | "WordBuilderIntl" | "SignInIntl" | "HomeIntl" | "ProfileIntl" | "SavedWordsIntl" | "MyRequestsIntl" | "SearchHistoryIntl" | "LogoutIntl" | "AnnouncementsIntl" | "ContributeWordIntl" | "DonateIntl" | "PronunciationsIntl" | "ariaAvatar" | "ariaMenu" | "ariaLanguages" | "ariaSwitchTheme" | "ariaBlur" | "ContributeIntl" | "FeedbackIntl" | "LearnIntl" | "FlashcardGameIntl" | "WordMatchingGameIntl" | "SpeedRoundGameIntl" | "ForeignTermSuggestionsIntl" | "SearchIntl" | "DashboardIntl", string>;
 
 export default function Navbar({
   session,
@@ -48,6 +48,7 @@ export default function Navbar({
   LogoutIntl,
   AnnouncementsIntl,
   ContributeWordIntl,
+  DonateIntl,
   PronunciationsIntl,
   ariaAvatar,
   setIsSidebarOpen,
@@ -76,7 +77,7 @@ export default function Navbar({
     pathName
   );
   const snap = useSnapshot(preferencesState);
-  const isContributeActive = ["/contribute-word", "/pronunciation-voting", "/feedback", "/foreign-term-suggestions"].some((route) => pathName.startsWith(route));
+  const isContributeActive = ["/contribute-word", "/donate", "/pronunciation-voting", "/feedback", "/foreign-term-suggestions"].some((route) => pathName.startsWith(route));
   const isLearnActive = ["/word-list", "/word-builder", "/flashcard-game", "/word-matching", "/speed-round"].some((route) => pathName.startsWith(route));
   const isHomeRoute = pathName === "/";
   const isSearchRoute =
@@ -175,6 +176,9 @@ export default function Navbar({
             }}>
             <DropdownItem key="contribute-word" as={NextIntlLink} href="/contribute-word" startContent={<HeartHandshake aria-label={ContributeWordIntl} className="w-4 h-4" />}>
               {ContributeWordIntl}
+            </DropdownItem>
+            <DropdownItem key="donate" as={NextIntlLink} href="/donate" startContent={<WalletCards aria-label={DonateIntl} className="w-4 h-4" />}>
+              {DonateIntl}
             </DropdownItem>
             <DropdownItem key="pronunciation-voting" as={NextIntlLink} href="/pronunciation-voting" startContent={<Mic aria-label={PronunciationsIntl} className="w-4 h-4" />}>
               {PronunciationsIntl}

--- a/src/components/customs/sidebar.tsx
+++ b/src/components/customs/sidebar.tsx
@@ -1,4 +1,4 @@
-import { BellIcon, Blocks, GitPullRequestArrow, Globe, HandHeart, HeartHandshake, HistoryIcon, HomeIcon, LayoutDashboard, Layers, Link2, ListTree, LogIn, MicIcon, Monitor, StarIcon, UserIcon, WifiOff, Sun, Moon, Sparkles, Sparkle, Languages, LogOut, Zap } from 'lucide-react'
+import { BellIcon, Blocks, GitPullRequestArrow, Globe, HandHeart, HeartHandshake, HistoryIcon, HomeIcon, LayoutDashboard, Layers, Link2, ListTree, LogIn, MicIcon, Monitor, StarIcon, UserIcon, WifiOff, Sun, Moon, Sparkles, Sparkle, Languages, LogOut, WalletCards, Zap } from 'lucide-react'
 import React from 'react'
 import { Link as NextIntlLink } from "@/src/i18n/routing";
 import { useRouter } from "@/src/i18n/routing";
@@ -109,6 +109,11 @@ export default function Sidebar(
                             <li>
                                 <NextIntlLink className='flex items-center gap-2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50 rounded-md' href={'/contribute-word'} onClick={() => setIsSidebarOpen(false)}>
                                     <HeartHandshake className="h-6 w-6" /> <span className={`text-nowrap`}>{t("Navbar.ContributeWord")}</span>
+                                </NextIntlLink>
+                            </li>
+                            <li>
+                                <NextIntlLink className='flex items-center gap-2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50 rounded-md' href={'/donate'} onClick={() => setIsSidebarOpen(false)}>
+                                    <WalletCards className="h-6 w-6" /> <span className={`text-nowrap`}>{t("Navbar.Donate")}</span>
                                 </NextIntlLink>
                             </li>
                             <li>

--- a/src/config/donation.ts
+++ b/src/config/donation.ts
@@ -1,0 +1,4 @@
+export const donationLinks = {
+  githubSponsors: "https://github.com/sponsors/4furki4",
+  patreon: process.env.NEXT_PUBLIC_PATREON_URL,
+};

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -38,6 +38,7 @@ export const env = createEnv({
     // NEXT_PUBLIC_CLIENTVAR: z.string(),
     NEXT_PUBLIC_RECAPTCHA_SITE_KEY: z.string().min(1),
     NEXT_PUBLIC_APP_URL: z.string().url().optional(),
+    NEXT_PUBLIC_PATREON_URL: z.string().url().optional(),
   },
 
   /**
@@ -60,6 +61,7 @@ export const env = createEnv({
     RECAPTCHA_SECRET_KEY: process.env.RECAPTCHA_SECRET_KEY,
     NEXT_PUBLIC_RECAPTCHA_SITE_KEY: process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    NEXT_PUBLIC_PATREON_URL: process.env.NEXT_PUBLIC_PATREON_URL,
     UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
     UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
   },

--- a/src/i18n/pathnames.ts
+++ b/src/i18n/pathnames.ts
@@ -19,6 +19,10 @@ export const pathnames = {
     en: "/contribute-word",
     tr: "/kelime-katkisi",
   },
+  "/donate": {
+    en: "/donate",
+    tr: "/destek-ol",
+  },
   "/dashboard": {
     en: "/dashboard",
     tr: "/panel",

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -40,6 +40,10 @@ export const routing = defineRouting({
       "en": "/contribute-word",
       "tr": "/kelime-katkisi",
     },
+    "/donate": {
+      "en": "/donate",
+      "tr": "/destek-ol",
+    },
     "/dashboard": {
       "en": "/dashboard",
       "tr": "/panel",


### PR DESCRIPTION
## Summary
- Added a localized donation page at `/donate` with Turkish and English routes, metadata, and a responsive support layout.
- Wired the page into the desktop Contribute menu, mobile sidebar, and footer community links.
- Added localized donation copy and a configurable Patreon URL alongside the GitHub Sponsors link.

## Testing
- `bun run build` passed.
- Verified the new Turkish and English donation routes return `200` locally and render the expected sponsor links and fallback Patreon state.