### PR TITLE
Update robots.txt to list all sitemap endpoints

### DIFF
--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -1,0 +1,15 @@
+/** @jest-environment node */
+
+import robots from "@/src/app/robots";
+
+describe("robots.txt metadata", () => {
+  it("lists the main sitemap plus directly crawlable sitemap files", () => {
+    const result = robots();
+
+    expect(result.sitemap).toContain("https://turkce-sozluk.com/sitemap.xml");
+    expect(result.sitemap).toContain("https://turkce-sozluk.com/sitemap-static.xml");
+    expect(result.sitemap).toContain("https://turkce-sozluk.com/sitemap-words/sitemap/1.xml");
+    expect(result.sitemap).toContain("https://turkce-sozluk.com/sitemap-words/sitemap/20.xml");
+    expect(result.sitemap).toHaveLength(22);
+  });
+});

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,8 +1,14 @@
 import { MetadataRoute } from "next";
 import { getBaseUrl } from '@/src/lib/seo-utils';
 
+const WORD_SITEMAP_PAGE_COUNT = 20;
+
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = getBaseUrl();
+  const wordSitemaps = Array.from(
+    { length: WORD_SITEMAP_PAGE_COUNT },
+    (_, index) => `${baseUrl}/sitemap-words/sitemap/${index + 1}.xml`,
+  );
 
   return {
     rules: [{
@@ -30,6 +36,10 @@ export default function robots(): MetadataRoute.Robots {
       disallow: "/",
     }
     ],
-    sitemap: [`${baseUrl}/sitemap.xml`],
+    sitemap: [
+      `${baseUrl}/sitemap.xml`,
+      `${baseUrl}/sitemap-static.xml`,
+      ...wordSitemaps,
+    ],
   };
 }


### PR DESCRIPTION
## Summary
- Add the static sitemap and all word sitemap pages to `robots.txt`
- Cover the expanded sitemap list with a node test

## Testing
- Added a unit test that asserts the robots metadata includes the expected sitemap URLs