### PR TITLE
Add collapsible related links to word detail views

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -513,6 +513,8 @@
     "RequestEdit": "Request Edit",
     "RelatedWords": "Related Words",
     "RelatedPhrases": "Related Phrases",
+    "ShowMore": "Show more ({count})",
+    "ShowLess": "Show less",
     "Pronunciations": "Pronunciations",
     "NavigationWord": "Navigation Word",
     "Root": "Root",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -513,6 +513,8 @@
     "RequestEdit": "Düzenleme Talep Et",
     "RelatedWords": "İlgili Kelimeler",
     "RelatedPhrases": "İlgili Atasözleri ve Deyimler",
+    "ShowMore": "Daha fazla göster ({count})",
+    "ShowLess": "Daha az göster",
     "Pronunciations": "Telaffuzlar",
     "NavigationWord": "Yönlendirilen Kelime",
     "Root": "Köken",

--- a/src/components/customs/search/__tests__/word-card-variants.test.tsx
+++ b/src/components/customs/search/__tests__/word-card-variants.test.tsx
@@ -31,6 +31,8 @@ jest.mock("next-intl", () => ({
         Pronunciations: "Pronunciations",
         RelatedWords: "Related Words",
         RelatedPhrases: "Related Phrases",
+        ShowMore: "Show more ({count})",
+        ShowLess: "Show less",
         Root: "Root",
         views: "views",
         RequestEdit: "Request Edit",
@@ -222,6 +224,29 @@ const sampleWord = {
   },
 };
 
+function buildWordWithRelatedLinks({
+  phraseCount,
+  wordCount = 0,
+}: {
+  phraseCount: number;
+  wordCount?: number;
+}) {
+  return {
+    word_data: {
+      ...sampleWord.word_data,
+      relatedWords: Array.from({ length: wordCount }, (_, index) => ({
+        related_word_id: index + 100,
+        related_word_name: `related word ${index + 1}`,
+        relation_type: "relatedWord",
+      })),
+      relatedPhrases: Array.from({ length: phraseCount }, (_, index) => ({
+        related_phrase_id: index + 200,
+        related_phrase: `related phrase ${index + 1}`,
+      })),
+    },
+  };
+}
+
 describe("SearchWordCardVariantGroup", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -383,5 +408,81 @@ describe("SearchWordCardVariantGroup", () => {
     fireEvent.click(requestPronunciationButtons[requestPronunciationButtons.length - 1]);
 
     expect(screen.getByTestId("request-modal-initial-view")).toHaveTextContent("pronunciation");
+  });
+
+  it("collapses long related phrase lists to the first 24 items", () => {
+    initializePreferences();
+
+    render(
+      <SearchWordCardVariantGroup
+        data={[buildWordWithRelatedLinks({ phraseCount: 30 })]}
+        locale="en"
+        session={null}
+        headingLevel="h1"
+      />,
+    );
+
+    expect(screen.getByText("related phrase 24")).toBeInTheDocument();
+    expect(screen.queryByText("related phrase 25")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show more (6)" })).toBeInTheDocument();
+  });
+
+  it("expands and collapses long related phrase lists", () => {
+    initializePreferences();
+
+    render(
+      <SearchWordCardVariantGroup
+        data={[buildWordWithRelatedLinks({ phraseCount: 30 })]}
+        locale="en"
+        session={null}
+        headingLevel="h1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more (6)" }));
+
+    expect(screen.getByText("related phrase 30")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+
+    expect(screen.queryByText("related phrase 25")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show more (6)" })).toBeInTheDocument();
+  });
+
+  it("does not show the related links toggle for lists at the limit", () => {
+    initializePreferences();
+
+    render(
+      <SearchWordCardVariantGroup
+        data={[buildWordWithRelatedLinks({ phraseCount: 24 })]}
+        locale="en"
+        session={null}
+        headingLevel="h1"
+      />,
+    );
+
+    expect(screen.getByText("related phrase 24")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Show more/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show less" })).not.toBeInTheDocument();
+  });
+
+  it("collapses long related phrase lists in compact layout", () => {
+    localStorage.setItem(SEARCH_WORD_CARD_VARIANT_STORAGE_KEY, "magazine");
+    initializePreferences();
+
+    render(
+      <SearchWordCardVariantGroup
+        data={[buildWordWithRelatedLinks({ phraseCount: 30 })]}
+        locale="en"
+        session={null}
+        headingLevel="h1"
+      />,
+    );
+
+    expect(screen.getByText("related phrase 24")).toBeInTheDocument();
+    expect(screen.queryByText("related phrase 25")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more (6)" }));
+
+    expect(screen.getByText("related phrase 30")).toBeInTheDocument();
   });
 });

--- a/src/components/customs/search/word-card-variants.tsx
+++ b/src/components/customs/search/word-card-variants.tsx
@@ -5,6 +5,8 @@ import {
   BookOpen,
   Blocks,
   Camera,
+  ChevronDown,
+  ChevronUp,
   Eye,
   Link as LinkIcon,
   PenLine,
@@ -51,6 +53,7 @@ const WORD_CARD_VARIANTS: {
     { value: "reader", labelKey: "ReadingLayout", icon: BookOpen },
     { value: "magazine", labelKey: "MagazineLayout", icon: Blocks },
   ];
+const RELATED_LINK_COLLAPSE_LIMIT = 24;
 
 type WordEntryData = WordSearchResult["word_data"] & {
   source?: "online" | "offline";
@@ -1022,8 +1025,11 @@ function CompactConnections({ word_data }: { word_data: WordEntryData }) {
     <div className="space-y-4 border-t border-border/70 pt-4">
       {relatedPhrases.length > 0 ? (
         <CompactConnectionBlock icon={BookOpen} title={t("RelatedPhrases")}>
-          <ul className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
-            {relatedPhrases.map((relatedPhrase) => (
+          <ExpandableConnectionList
+            as="ul"
+            items={relatedPhrases}
+            className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2"
+            renderItem={(relatedPhrase) => (
               <li key={relatedPhrase.related_phrase_id} className="min-w-0">
                 <Link
                   href={{
@@ -1039,18 +1045,20 @@ function CompactConnections({ word_data }: { word_data: WordEntryData }) {
                   <span className="truncate">{relatedPhrase.related_phrase}</span>
                 </Link>
               </li>
-            ))}
-          </ul>
+            )}
+          />
         </CompactConnectionBlock>
       ) : null}
 
       {relatedWords.length > 0 ? (
         <CompactConnectionBlock icon={LinkIcon} title={t("RelatedWords")}>
-          <div className="flex flex-wrap gap-x-3 gap-y-3">
-            {relatedWords.map((relatedWord) => (
+          <ExpandableConnectionList
+            items={relatedWords}
+            className="flex flex-wrap gap-x-3 gap-y-3"
+            renderItem={(relatedWord) => (
               <CompactRelatedWordLink key={relatedWord.related_word_id} relatedWord={relatedWord} />
-            ))}
-          </div>
+            )}
+          />
         </CompactConnectionBlock>
       ) : null}
     </div>
@@ -1125,30 +1133,38 @@ function ConnectionsSection({
       >
         {relatedWords.length > 0 ? (
           <ConnectionGroup title={t("RelatedWords")}>
-            {relatedWords.map((relatedWord) => (
-              <RelatedWordLink key={relatedWord.related_word_id} relatedWord={relatedWord} compact={compact} />
-            ))}
+            <ExpandableConnectionList
+              items={relatedWords}
+              className="flex flex-wrap gap-x-4 gap-y-2"
+              renderItem={(relatedWord) => (
+                <RelatedWordLink key={relatedWord.related_word_id} relatedWord={relatedWord} compact={compact} />
+              )}
+            />
           </ConnectionGroup>
         ) : null}
 
         {relatedPhrases.length > 0 ? (
           <ConnectionGroup title={t("RelatedPhrases")}>
-            {relatedPhrases.map((relatedPhrase) => (
-              <Link
-                key={relatedPhrase.related_phrase_id}
-                href={{
-                  pathname: "/search/[word]",
-                  params: { word: relatedPhrase.related_phrase },
-                }}
-                prefetch={false}
-                className={cn(
-                  "text-sm text-primary underline decoration-primary/60 underline-offset-4 transition-colors hover:decoration-primary hover:text-primary/80",
-                  compact && "text-xs",
-                )}
-              >
-                {relatedPhrase.related_phrase}
-              </Link>
-            ))}
+            <ExpandableConnectionList
+              items={relatedPhrases}
+              className="flex flex-wrap gap-x-4 gap-y-2"
+              renderItem={(relatedPhrase) => (
+                <Link
+                  key={relatedPhrase.related_phrase_id}
+                  href={{
+                    pathname: "/search/[word]",
+                    params: { word: relatedPhrase.related_phrase },
+                  }}
+                  prefetch={false}
+                  className={cn(
+                    "text-sm text-primary underline decoration-primary/60 underline-offset-4 transition-colors hover:decoration-primary hover:text-primary/80",
+                    compact && "text-xs",
+                  )}
+                >
+                  {relatedPhrase.related_phrase}
+                </Link>
+              )}
+            />
           </ConnectionGroup>
         ) : null}
       </div>
@@ -1160,8 +1176,45 @@ function ConnectionGroup({ title, children }: { title: string; children: ReactNo
   return (
     <div>
       <h3 className="text-sm font-semibold text-muted-foreground">{title}</h3>
-      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">{children}</div>
+      <div className="mt-3">{children}</div>
     </div>
+  );
+}
+
+function ExpandableConnectionList<T>({
+  as = "div",
+  items,
+  className,
+  renderItem,
+}: {
+  as?: "div" | "ul";
+  items: readonly T[];
+  className: string;
+  renderItem: (item: T) => ReactNode;
+}) {
+  const t = useTranslations("WordCard");
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasOverflow = items.length > RELATED_LINK_COLLAPSE_LIMIT;
+  const visibleItems = hasOverflow && !isExpanded ? items.slice(0, RELATED_LINK_COLLAPSE_LIMIT) : items;
+  const hiddenCount = Math.max(items.length - RELATED_LINK_COLLAPSE_LIMIT, 0);
+  const ToggleIcon = isExpanded ? ChevronUp : ChevronDown;
+  const Container = as;
+
+  return (
+    <>
+      <Container className={className}>{visibleItems.map(renderItem)}</Container>
+      {hasOverflow ? (
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          onClick={() => setIsExpanded((current) => !current)}
+          className="mt-3 inline-flex min-h-8 items-center gap-1.5 rounded-md border border-border/70 bg-background/40 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+        >
+          <span>{isExpanded ? t("ShowLess") : t("ShowMore", { count: hiddenCount })}</span>
+          <ToggleIcon className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Added a reusable expandable list for related words and related phrases in the word detail views.
- Long connection lists now show the first 24 items by default and expose localized `Show more` / `Show less` controls.
- Kept the existing link styling and applied the same behavior in both reading and compact layouts.

## Testing
- Added unit coverage for collapsed, expanded, and limit-threshold behavior in the word card variant tests.
- Verified with the focused Jest suite and TypeScript check; both passed.